### PR TITLE
keygen: retry when key generation (or saving) failed

### DIFF
--- a/src/key-generator.js
+++ b/src/key-generator.js
@@ -104,6 +104,10 @@ KeyGenerator.prototype._generateNewKeys = function _generateNewKeys() {
 					this._keyGenerationTask = undefined;
 					return this._currentPrivateKey;
 				});
+		})
+		.catch(() => {
+			return new Promise(resolve => setTimeout(resolve, 100).unref())
+				.then(this._generateNewKeys);
 		});
 
 	return this._keyGenerationTask;


### PR DESCRIPTION
@j3parker this was the best I can think of given we're handling regeneration differently (timer vs on-request in c#)