### PR TITLE
refact: use native Promises instead of Bluebird

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "test": "npm run check-deps && npm run test-all"
   },
   "dependencies": {
-    "bluebird": "^3.5.1",
     "jwk-allowed-algorithms": "^1.0.0",
     "jwk-to-pem": "^1.2.6",
     "jws": "^3.1.4",

--- a/packages/node_modules/brightspace-auth-provisioning/src/abstract-provisioning-cache.js
+++ b/packages/node_modules/brightspace-auth-provisioning/src/abstract-provisioning-cache.js
@@ -2,7 +2,7 @@
 
 var inherits = require('util').inherits,
 	jws = require('jws'),
-	Promise = require('bluebird'),
+	promised = require('promised-method'),
 	qs = require('querystring'),
 	xtend = require('xtend');
 
@@ -18,9 +18,11 @@ function ValueLookupFailed(inner) {
 }
 inherits(ValueLookupFailed, Error);
 
+function noop() {}
+
 function AbstractProvisioningCache() {}
 
-AbstractProvisioningCache.prototype.get = Promise.method(/* @this */ function get(claims, scope) {
+AbstractProvisioningCache.prototype.get = promised(/* @this */ function get(claims, scope) {
 	if ('object' !== typeof claims) {
 		throw new Error('"claims" must be an Object');
 	}
@@ -60,7 +62,7 @@ AbstractProvisioningCache.prototype.get = Promise.method(/* @this */ function ge
 		});
 });
 
-AbstractProvisioningCache.prototype.set = Promise.method(/* @this */ function set(claims, scope, token) {
+AbstractProvisioningCache.prototype.set = promised(/* @this */ function set(claims, scope, token) {
 	if ('object' !== typeof claims) {
 		throw new Error('"claims" must be an Object');
 	}
@@ -91,7 +93,7 @@ AbstractProvisioningCache.prototype.set = Promise.method(/* @this */ function se
 
 	return Promise
 		.resolve(this._set(key, token, expiry))
-		.return(undefined);
+		.then(noop);
 });
 
 AbstractProvisioningCache.prototype._buildKey = function buildKey(claims, scope) {

--- a/packages/node_modules/brightspace-auth-provisioning/src/index.js
+++ b/packages/node_modules/brightspace-auth-provisioning/src/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var jws = require('jws'),
-	Promise = require('bluebird'),
+	promised = require('promised-method'),
 	qs = require('querystring'),
 	request = require('superagent'),
 	uuid = require('uuid/v4'),
@@ -48,7 +48,7 @@ function AuthTokenProvisioner(opts) {
 	this._tokenEndpoint = remoteIssuer + TOKEN_PATH;
 }
 
-AuthTokenProvisioner.prototype.provisionToken = Promise.method(/* @this */ function provisionToken(opts) {
+AuthTokenProvisioner.prototype.provisionToken = promised(/* @this */ function provisionToken(opts) {
 	var self = this;
 
 	opts = opts || {};


### PR DESCRIPTION
Bluebird is definitely still faster, but native Promises have made great strides in closing the gap. As well, the integration of native promises for tracing and debuggability are quite desirable, so continuing to transition libraries over (especially as native Promise is now widely available on the node.js versions we expect people to be running.

> Marked as semver major because native Promise is now definitely required, and while not documented, Bluebird Promises could have been expected in consumption.

Orig: https://github.com/Brightspace/node-auth-provisioning/pull/26