### PR TITLE
provisioning: check if signingKey is null

### DIFF
--- a/packages/node_modules/brightspace-auth-provisioning/src/index.js
+++ b/packages/node_modules/brightspace-auth-provisioning/src/index.js
@@ -110,7 +110,8 @@ AuthTokenProvisioner.prototype._buildAssertion = function buildAssertion(payload
 	return self
 		._latestKey()
 		.then(function(signingKey) {
-			if ('object' !== typeof signingKey
+			if (null === signingKey
+				|| 'object' !== typeof signingKey
 				|| 'string' !== typeof signingKey.kid
 				|| 'string' !== typeof signingKey.pem
 			) {


### PR DESCRIPTION
End up in approximately the same state, but this is more correct and
ensures that the correct error is thrown.

Fixes: https://github.com/Brightspace/node-auth/issues/62