### PR TITLE
Treat decoded payload as JSON string so cache can function

### DIFF
--- a/packages/node_modules/brightspace-auth-provisioning/src/abstract-provisioning-cache.js
+++ b/packages/node_modules/brightspace-auth-provisioning/src/abstract-provisioning-cache.js
@@ -49,11 +49,14 @@ AbstractProvisioningCache.prototype.get = promised(/* @this */ function get(clai
 			}
 
 			var decodedToken = jws.decode(token);
+			var payload;
+			if ('object' === typeof decodedToken) {
+				payload = JSON.parse(decodedToken.payload);
+			}
 
-			if ('object' !== typeof decodedToken
-				|| 'object' !== typeof decodedToken.payload
-				|| 'number' !== typeof decodedToken.payload.exp
-				|| (decodedToken.payload.exp - EXPIRY_BUFFER_TIME_SECONDS) <= clock()
+			if ('object' !== typeof payload
+				|| 'number' !== typeof payload.exp
+				|| (payload.exp - EXPIRY_BUFFER_TIME_SECONDS) <= clock()
 			) {
 				throw new ValueLookupFailed();
 			}
@@ -76,7 +79,11 @@ AbstractProvisioningCache.prototype.set = promised(/* @this */ function set(clai
 	}
 
 	var decodedToken = jws.decode(token);
-	if ('object' !== typeof decodedToken || 'object' !== typeof decodedToken.payload) {
+	var payload;
+	if ('object' === typeof decodedToken) {
+		payload = JSON.parse(decodedToken.payload);
+	}
+	if ('object' !== typeof payload) {
 		throw new Error('"token" must be an encoded jwt');
 	}
 
@@ -86,8 +93,8 @@ AbstractProvisioningCache.prototype.set = promised(/* @this */ function set(clai
 
 	var key = this._buildKey(claims, scope);
 
-	var expiry = 'number' === typeof decodedToken.payload.exp
-		? decodedToken.payload.exp
+	var expiry = 'number' === typeof payload.exp
+		? payload.exp
 		: DEFAULT_EXPIRY_SECONDS + clock();
 	expiry -= EXPIRY_BUFFER_TIME_SECONDS;
 


### PR DESCRIPTION
`jws.encode()` does `JSON.stringify()` on the token payload (https://www.npmjs.com/package/jws).

So, the check here that the payload is an object, so far as I can tell, always fails.

Because the provisioner catches silently (https://github.com/Brightspace/node-auth/blob/master/packages/node_modules/brightspace-auth-provisioning/src/index.js#L99), this means this cache does nothing; this change should fix that.