### PR TITLE
validation, tests: replace co-mocha usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "aws-sdk": "^2.179.0",
     "chai": "^4.1.1",
     "chai-as-promised": "^7.1.1",
-    "co-mocha": "^1.2.1",
     "coveralls": "^3.0.0",
     "dynamodb-local": "0.0.25",
     "eslint": "^5.13.0",

--- a/packages/node_modules/brightspace-auth-validation/package.json
+++ b/packages/node_modules/brightspace-auth-validation/package.json
@@ -9,6 +9,6 @@
   ],
   "main": "src/index.js",
   "scripts": {
-    "test": "nyc --all --produce-source-map --require source-map-support mocha -r co-mocha -R spec spec"
+    "test": "nyc --all --produce-source-map --require source-map-support mocha -R spec spec"
   }
 }

--- a/packages/node_modules/brightspace-auth-validation/spec/validation.spec.js
+++ b/packages/node_modules/brightspace-auth-validation/spec/validation.spec.js
@@ -99,7 +99,7 @@ describe('validations', function() {
 			.to.be.rejectedWith(AuthTokenValidator.errors.BadToken);
 	});
 
-	it('should throw "BadToken" for bad signature', function *() {
+	it('should throw "BadToken" for bad signature', async function() {
 		token = jwt.sign({}, privateKeyPem, {
 			algorithm: 'RS256',
 			header: {
@@ -116,13 +116,13 @@ describe('validations', function() {
 				keys: [jwk]
 			});
 
-		yield expect(validator.fromHeaders({ authorization: `Bearer ${token}` }))
+		await expect(validator.fromHeaders({ authorization: `Bearer ${token}` }))
 			.to.be.rejectedWith(AuthTokenValidator.errors.BadToken);
 
 		jwkInterceptor.done();
 	});
 
-	it('should throw "PublicKeyNotFound" when no key with matching "kid" is found on auth server', function *() {
+	it('should throw "PublicKeyNotFound" when no key with matching "kid" is found on auth server', async function() {
 		token = jwt.sign({}, privateKeyPem, {
 			algorithm: 'RS256',
 			header: {
@@ -137,13 +137,13 @@ describe('validations', function() {
 				keys: [jwk]
 			});
 
-		yield expect(validator.fromHeaders({ authorization: `Bearer ${ token }` }))
+		await expect(validator.fromHeaders({ authorization: `Bearer ${ token }` }))
 			.to.be.rejectedWith(AuthTokenValidator.errors.PublicKeyNotFound);
 
 		jwkInterceptor.done();
 	});
 
-	it('should throw "PublicKeyNotFound" when key with matching "kid" was found, but had a past exp', function*() {
+	it('should throw "PublicKeyNotFound" when key with matching "kid" was found, but had a past exp', async function() {
 		token = jwt.sign({}, privateKeyPem, {
 			algorithm: 'RS256',
 			header: {
@@ -158,13 +158,13 @@ describe('validations', function() {
 				keys: [Object.assign({}, jwk, { exp: Date.now() - maxClockSkew })]
 			});
 
-		yield expect(validator.fromHeaders({ authorization: `Bearer ${token}` }))
+		await expect(validator.fromHeaders({ authorization: `Bearer ${token}` }))
 			.to.be.rejectedWith(AuthTokenValidator.errors.PublicKeyNotFound);
 
 		jwkInterceptor.done();
 	});
 
-	it('should throw "PublicKeyLookupFailed" when there is an error requesting the jwks', function *() {
+	it('should throw "PublicKeyLookupFailed" when there is an error requesting the jwks', async function() {
 		token = jwt.sign({}, privateKeyPem, {
 			algorithm: 'RS256',
 			header: {
@@ -177,13 +177,13 @@ describe('validations', function() {
 			.get(JWKS_PATH)
 			.reply(404);
 
-		yield expect(validator.fromHeaders({ authorization: `Bearer ${ token }` }))
+		await expect(validator.fromHeaders({ authorization: `Bearer ${ token }` }))
 			.to.be.rejectedWith(AuthTokenValidator.errors.PublicKeyLookupFailed);
 
 		jwkInterceptor.done();
 	});
 
-	it('should NOT throw "PublicKeyLookupFailed" when there WAS error requesting the jwks', function *() {
+	it('should NOT throw "PublicKeyLookupFailed" when there WAS error requesting the jwks', async function() {
 		token = jwt.sign({}, privateKeyPem, {
 			algorithm: 'RS256',
 			header: {
@@ -196,7 +196,7 @@ describe('validations', function() {
 			.get(JWKS_PATH)
 			.reply(404);
 
-		yield expect(validator.fromHeaders({ authorization: `Bearer ${ token }` }))
+		await expect(validator.fromHeaders({ authorization: `Bearer ${ token }` }))
 			.to.be.rejectedWith(AuthTokenValidator.errors.PublicKeyLookupFailed);
 
 		jwkInterceptor.done();
@@ -219,7 +219,7 @@ describe('validations', function() {
 				keys: [jwk]
 			});
 
-		token = yield validator.fromHeaders({
+		token = await validator.fromHeaders({
 			authorization: `Bearer ${ signature }`
 		});
 		expect(token).to.be.instanceof(BrightspaceAuthToken);
@@ -228,7 +228,7 @@ describe('validations', function() {
 		jwkInterceptor.done();
 	});
 
-	it('should return BrightspaceAuthToken when matching "kid" is found on auth server and signature is valid', function *() {
+	it('should return BrightspaceAuthToken when matching "kid" is found on auth server and signature is valid', async function() {
 		const
 			payload = {
 				key: 'val'
@@ -247,7 +247,7 @@ describe('validations', function() {
 				keys: [jwk]
 			});
 
-		token = yield validator.fromHeaders({
+		token = await validator.fromHeaders({
 			authorization: `Bearer ${ signature }`
 		});
 		expect(token).to.be.instanceof(BrightspaceAuthToken);
@@ -256,7 +256,7 @@ describe('validations', function() {
 		jwkInterceptor.done();
 	});
 
-	it('should return BrightspaceAuthToken when matching "kid" is found on auth server, signature is valid, and expiry is within clock skew', function *() {
+	it('should return BrightspaceAuthToken when matching "kid" is found on auth server, signature is valid, and expiry is within clock skew', async function() {
 		const
 			payload = {
 				key: 'val'
@@ -276,7 +276,7 @@ describe('validations', function() {
 				keys: [jwk]
 			});
 
-		token = yield validator.fromHeaders({
+		token = await validator.fromHeaders({
 			authorization: `Bearer ${ signature }`
 		});
 		expect(token).to.be.instanceof(BrightspaceAuthToken);
@@ -285,7 +285,7 @@ describe('validations', function() {
 		jwkInterceptor.done();
 	});
 
-	it('should return BrightspaceAuthToken when matching "kid" is found on auth server, signature is valid and nbf is within clock skew', function *() {
+	it('should return BrightspaceAuthToken when matching "kid" is found on auth server, signature is valid and nbf is within clock skew', async function() {
 		const
 			payload = {
 				key: 'val'
@@ -305,7 +305,7 @@ describe('validations', function() {
 				keys: [jwk]
 			});
 
-		token = yield validator.fromHeaders({
+		token = await validator.fromHeaders({
 			authorization: `Bearer ${ signature }`
 		});
 		expect(token).to.be.instanceof(BrightspaceAuthToken);
@@ -314,7 +314,7 @@ describe('validations', function() {
 		jwkInterceptor.done();
 	});
 
-	it('should return BrightspaceAuthToken even when more than one space separates "Bearer" and the signature', function *() {
+	it('should return BrightspaceAuthToken even when more than one space separates "Bearer" and the signature', async function() {
 		const
 			payload = {
 				key: 'val'
@@ -334,7 +334,7 @@ describe('validations', function() {
 				keys: [jwk]
 			});
 
-		token = yield validator.fromHeaders({
+		token = await validator.fromHeaders({
 			authorization: `Bearer     ${ signature }`
 		});
 		expect(token).to.be.instanceof(BrightspaceAuthToken);
@@ -344,7 +344,7 @@ describe('validations', function() {
 	});
 
 	describe('validateConfiguration', function() {
-		it('should return true when public keys can be updated', function *() {
+		it('should return true when public keys can be updated', async function() {
 			jwkInterceptor = nock(ISSUER)
 				.get(JWKS_PATH)
 				.reply(200, {
@@ -355,7 +355,7 @@ describe('validations', function() {
 				issuer: ISSUER
 			});
 
-			yield expect(auth.validateConfiguration()).to.eventually.be.true;
+			await expect(auth.validateConfiguration()).to.eventually.be.true;
 
 			jwkInterceptor.done();
 		});


### PR DESCRIPTION
PR-URL: https://github.com/Brightspace/node-auth/pull/112