### PR TITLE
keys: make KeyGenerator an EventEmitter

### DIFF
--- a/packages/node_modules/brightspace-auth-keys/src/key-generator.js
+++ b/packages/node_modules/brightspace-auth-keys/src/key-generator.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const EventEmitter = require('events');
+
 const CoreKeyGenerator = require('./core-key-generator');
 const clock = require('./clock');
 
@@ -12,12 +14,14 @@ const MAXIMUM_SIGNING_KEY_USE = 23 * 60 * 60;
 const DEFAULT_MAX_TOKEN_LIFETIME = 5 * 60;
 const MINIMUM_MAX_TOKEN_LIFETIME = 5 * 60;
 
-class KeyGenerator {
+class KeyGenerator extends EventEmitter {
 
 	constructor(opts) {
 		if (typeof opts !== 'object') {
 			throw new TypeError(`"opts" should be an Object. Got "${typeof opts}".`);
 		}
+
+		super();
 
 		this._core = new CoreKeyGenerator(opts);
 
@@ -87,6 +91,7 @@ class KeyGenerator {
 
 				return { key, keyUseExpiry };
 			} catch (err) {
+				this.emit('error', err);
 				await delay(100);
 			}
 		}

--- a/packages/node_modules/brightspace-auth-keys/test/key-generator.js
+++ b/packages/node_modules/brightspace-auth-keys/test/key-generator.js
@@ -12,14 +12,12 @@ const EXPIRY_CLOCK_SKEW = 5 * 60;
 const TEST_SIGNING_KEY_USE = 60 * 60;
 const TEST_TOKEN_LIFETIME = 5 * 60;
 
-const
-	dummyPublicKeyStore = new DummyPublicKeyStore();
-
 describe('KeyGenerator', () => {
-	let clock;
+	let clock, dummyPublicKeyStore;
 
 	beforeEach(() => {
 		clock = sinon.useFakeTimers();
+		dummyPublicKeyStore = new DummyPublicKeyStore();
 	});
 
 	afterEach(() => {
@@ -173,6 +171,31 @@ describe('KeyGenerator', () => {
 							+ EXPIRY_CLOCK_SKEW
 					})
 				);
+			});
+		});
+
+		describe('failure', () => {
+			it('should emit the error, and retry', async() => {
+				clock.restore();
+
+				const failure = new Error('error that should be emitted');
+
+				dummyPublicKeyStore
+					.storePublicKey
+					.onFirstCall().rejects(failure)
+					.onSecondCall().resolves()
+					.resolves();
+
+				const keygen = createKeyGenerator({ signingKeyType: 'EC' });
+				const emittedError = new Promise(resolve => {
+					keygen.once('error', resolve);
+				});
+
+				assert.strictEqual(await emittedError, failure);
+
+				await keygen.getCurrentPrivateKey();
+
+				sinon.assert.calledTwice(dummyPublicKeyStore.storePublicKey);
 			});
 		});
 	});


### PR DESCRIPTION
emit error events when generating a key fails

PR-URL: https://github.com/Brightspace/node-auth/pull/122