### PR TITLE
Revert use of KeyObjects

### DIFF
--- a/packages/node_modules/brightspace-auth-keys/src/ec-key-generator.js
+++ b/packages/node_modules/brightspace-auth-keys/src/ec-key-generator.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { generateKeyPair, createPublicKey } = require('crypto');
+const { generateKeyPair } = require('crypto');
 
 const keyto = require('@trust/keyto');
 
@@ -12,17 +12,14 @@ const CRV_TO_ALG = {
 	'P-521': 'ES512'
 };
 
-const SUPPORTS_KEY_OBJECTS = typeof createPublicKey === 'function';
 const PUBLIC_EXPORT_OPTIONS = {
 	type: 'spki',
 	format: 'pem'
 };
-const PRIVATE_EXPORT_OPTIONS = SUPPORTS_KEY_OBJECTS
-	? null
-	: {
-		type: 'pkcs8',
-		format: 'pem'
-	};
+const PRIVATE_EXPORT_OPTIONS = {
+	type: 'pkcs8',
+	format: 'pem'
+};
 
 function keygen(opts, kid) {
 	return new Promise((resolve, reject) => {

--- a/packages/node_modules/brightspace-auth-keys/src/rsa-key-generator.js
+++ b/packages/node_modules/brightspace-auth-keys/src/rsa-key-generator.js
@@ -1,23 +1,20 @@
 'use strict';
 
-const { generateKeyPair, createPublicKey } = require('crypto');
+const { generateKeyPair } = require('crypto');
 
 const keyto = require('@trust/keyto');
 
 const DEFAULT_SIZE = 2048;
 const MINIMUM_SIZE = 2048;
 
-const SUPPORTS_KEY_OBJECTS = typeof createPublicKey === 'function';
 const PUBLIC_EXPORT_OPTIONS = {
 	type: 'spki',
 	format: 'pem'
 };
-const PRIVATE_EXPORT_OPTIONS = SUPPORTS_KEY_OBJECTS
-	? null
-	: {
-		type: 'pkcs8',
-		format: 'pem'
-	};
+const PRIVATE_EXPORT_OPTIONS = {
+	type: 'pkcs8',
+	format: 'pem'
+};
 
 function keygen(opts, kid) {
 	return new Promise((resolve, reject) => {

--- a/packages/node_modules/brightspace-auth-keys/test/ec-key-generator.js
+++ b/packages/node_modules/brightspace-auth-keys/test/ec-key-generator.js
@@ -4,7 +4,6 @@ const assert = require('assert');
 
 const keygen = require('../src/ec-key-generator');
 
-const SUPPORTS_KEY_OBJECTS = typeof require('crypto').createPublicKey === 'function';
 const TEST_UUID = '1234';
 
 describe('EC', () => {
@@ -50,11 +49,7 @@ describe('EC', () => {
 
 					assert.strictEqual(typeof signingKey, 'object');
 					assert.strictEqual(signingKey.kid, TEST_UUID);
-					if (SUPPORTS_KEY_OBJECTS) {
-						assert.strictEqual(typeof signingKey.key, 'object');
-					} else {
-						assert.strictEqual(typeof signingKey.key, 'string');
-					}
+					assert.strictEqual(typeof signingKey.key, 'string');
 					assert.strictEqual(signingKey.alg, { 'P-256': 'ES256', 'P-384': 'ES384', 'P-521': 'ES512' }[crv]);
 				});
 

--- a/packages/node_modules/brightspace-auth-keys/test/rsa-key-generator.js
+++ b/packages/node_modules/brightspace-auth-keys/test/rsa-key-generator.js
@@ -4,7 +4,6 @@ const assert = require('assert');
 
 const keygen = require('../src/rsa-key-generator');
 
-const SUPPORTS_KEY_OBJECTS = typeof require('crypto').createPublicKey === 'function';
 const TEST_UUID = '1234';
 
 describe('RSA', () => {
@@ -85,11 +84,7 @@ describe('RSA', () => {
 
 			assert.strictEqual(typeof signingKey, 'object');
 			assert.strictEqual(signingKey.kid, TEST_UUID);
-			if (SUPPORTS_KEY_OBJECTS) {
-				assert.strictEqual(typeof signingKey.key, 'object');
-			} else {
-				assert.strictEqual(typeof signingKey.key, 'string');
-			}
+			assert.strictEqual(typeof signingKey.key, 'string');
 			assert.strictEqual(signingKey.alg, 'RS256');
 		});
 

--- a/packages/node_modules/brightspace-auth-provisioning/src/index.js
+++ b/packages/node_modules/brightspace-auth-provisioning/src/index.js
@@ -16,8 +16,6 @@ const DEFAULT_REMOTE_ISSUER = 'https://auth.brightspace.com/core';
 const TOKEN_PATH = '/connect/token';
 const SUPPORTED_ALGS = ['ES256', 'ES384', 'ES512', 'RS256'/*, 'RS384', 'RS512'*/]; // D2L.Security.OAuth2 assumes RS256
 
-const SUPPORTS_KEY_OBJECTS = typeof require('crypto').createPublicKey === 'function';
-
 class AuthTokenProvisioner {
 	constructor(opts) {
 		opts = opts || {};
@@ -99,10 +97,7 @@ class AuthTokenProvisioner {
 			|| 'object' !== typeof signingKey
 			|| 'string' !== typeof signingKey.kid
 			|| !SUPPORTED_ALGS.includes(signingKey.alg)
-			|| (
-				(SUPPORTS_KEY_OBJECTS && 'object' !== typeof signingKey.key)
-				|| (!SUPPORTS_KEY_OBJECTS && 'string' !== typeof signingKey.key)
-			)
+			|| 'string' !== typeof signingKey.key
 		) {
 			throw new Error('received invalid signing key from "keyLookup"');
 		}


### PR DESCRIPTION
Partial revert of https://github.com/Brightspace/node-auth/pull/113.

Private keys were returned as strings in Node 10 and as KeyObjects in Node 12. Now private keys are always returned as strings to maintain backwards compatibility regardless of Node version. A followup PR will switch to exclusively returning KeyObjects with a major version bump that also requires Node 12.