### PR TITLE
Always use KeyObjects for private keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: false
 dist: trusty
 language: node_js
 node_js:
-- 10
-- 11
 - 12
 - 14
 services:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/Brightspace/node-auth#readme",
   "engines": {
-    "node": ">=10.12.0"
+    "node": ">=12.x"
   },
   "private": true,
   "scripts": {

--- a/packages/node_modules/brightspace-auth-keys/src/ec-key-generator.js
+++ b/packages/node_modules/brightspace-auth-keys/src/ec-key-generator.js
@@ -16,10 +16,7 @@ const PUBLIC_EXPORT_OPTIONS = {
 	type: 'spki',
 	format: 'pem'
 };
-const PRIVATE_EXPORT_OPTIONS = {
-	type: 'pkcs8',
-	format: 'pem'
-};
+const PRIVATE_EXPORT_OPTIONS = null;
 
 function keygen(opts, kid) {
 	return new Promise((resolve, reject) => {

--- a/packages/node_modules/brightspace-auth-keys/src/rsa-key-generator.js
+++ b/packages/node_modules/brightspace-auth-keys/src/rsa-key-generator.js
@@ -11,10 +11,7 @@ const PUBLIC_EXPORT_OPTIONS = {
 	type: 'spki',
 	format: 'pem'
 };
-const PRIVATE_EXPORT_OPTIONS = {
-	type: 'pkcs8',
-	format: 'pem'
-};
+const PRIVATE_EXPORT_OPTIONS = null;
 
 function keygen(opts, kid) {
 	return new Promise((resolve, reject) => {

--- a/packages/node_modules/brightspace-auth-keys/test/ec-key-generator.js
+++ b/packages/node_modules/brightspace-auth-keys/test/ec-key-generator.js
@@ -49,7 +49,7 @@ describe('EC', () => {
 
 					assert.strictEqual(typeof signingKey, 'object');
 					assert.strictEqual(signingKey.kid, TEST_UUID);
-					assert.strictEqual(typeof signingKey.key, 'string');
+					assert.strictEqual(typeof signingKey.key, 'object');
 					assert.strictEqual(signingKey.alg, { 'P-256': 'ES256', 'P-384': 'ES384', 'P-521': 'ES512' }[crv]);
 				});
 

--- a/packages/node_modules/brightspace-auth-keys/test/rsa-key-generator.js
+++ b/packages/node_modules/brightspace-auth-keys/test/rsa-key-generator.js
@@ -84,7 +84,7 @@ describe('RSA', () => {
 
 			assert.strictEqual(typeof signingKey, 'object');
 			assert.strictEqual(signingKey.kid, TEST_UUID);
-			assert.strictEqual(typeof signingKey.key, 'string');
+			assert.strictEqual(typeof signingKey.key, 'object');
 			assert.strictEqual(signingKey.alg, 'RS256');
 		});
 

--- a/packages/node_modules/brightspace-auth-provisioning/src/index.js
+++ b/packages/node_modules/brightspace-auth-provisioning/src/index.js
@@ -97,7 +97,7 @@ class AuthTokenProvisioner {
 			|| 'object' !== typeof signingKey
 			|| 'string' !== typeof signingKey.kid
 			|| !SUPPORTED_ALGS.includes(signingKey.alg)
-			|| 'string' !== typeof signingKey.key
+			|| 'object' !== typeof signingKey.key
 		) {
 			throw new Error('received invalid signing key from "keyLookup"');
 		}

--- a/packages/node_modules/brightspace-auth-validation/src/index.js
+++ b/packages/node_modules/brightspace-auth-validation/src/index.js
@@ -38,7 +38,7 @@ function processJwks(jwks, knownPublicKeys, maxKeyAge, skew) {
 
 		const key = knownPublicKeys.has(jwk.kid)
 			? knownPublicKeys.get(jwk.kid).key
-			: createPublicKey ? createPublicKey(jwkToPem(jwk)) : jwkToPem(jwk);
+			: createPublicKey(jwkToPem(jwk));
 		const allowedAlgorithms = jwkAllowedAlgorithms(jwk);
 
 		const keyExpiry = typeof jwk.exp === 'number'


### PR DESCRIPTION
Part 2 of #148. Requires major version bump.