### PR TITLE
Bump superagent from 4.1 to 7.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "jwk-allowed-algorithms": "^1.0.0",
     "jwk-to-pem": "^2.0.0",
     "jws": "^4.0.0",
-    "superagent": "^4.1.0",
+    "superagent": "^7.1.3",
     "uuid": "^8.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Superagent relies on formidable. SA 7 upgrades to formidable 2.x. Formidable 1 is unsupported.