### PR TITLE
remove registry-url from Brightspace/setup-node

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,6 @@ jobs:
       - uses: Brightspace/setup-node@main
         with:
           node-version: 24
-          registry-url: 'https://registry.npmjs.org'
 
       - run: npm install
       - run: ./bin/do-release.sh

--- a/bin/do-release.sh
+++ b/bin/do-release.sh
@@ -27,6 +27,6 @@ for package in $(get_packages); do
 	if [ ! -z "${DRY_RUN}" ]; then
 		echo "Dry run. Skipping..."
 	else
-		npm publish --provenance --access public
+		npm publish --provenance --access public --registry https://registry.npmjs.org/
 	fi
 done

--- a/packages/node_modules/brightspace-auth-assertions/package.json
+++ b/packages/node_modules/brightspace-auth-assertions/package.json
@@ -8,6 +8,9 @@
     "LICENSE"
   ],
   "main": "src/index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "scripts": {
     "test": "nyc --all --exclude spec mocha --node-option enable-source-maps spec"
   }

--- a/packages/node_modules/brightspace-auth-keys-dynamodb-store/package.json
+++ b/packages/node_modules/brightspace-auth-keys-dynamodb-store/package.json
@@ -11,6 +11,9 @@
     "README.md",
     "LICENSE"
   ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "peerDependencies": {
     "aws-sdk": "^2.179.0",
     "brightspace-auth-keys": ""

--- a/packages/node_modules/brightspace-auth-keys-redis-store/package.json
+++ b/packages/node_modules/brightspace-auth-keys-redis-store/package.json
@@ -7,6 +7,9 @@
     "README.md",
     "LICENSE"
   ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "scripts": {
     "test": "nyc --all mocha --node-option enable-source-maps --recursive ./test"
   },

--- a/packages/node_modules/brightspace-auth-keys/package.json
+++ b/packages/node_modules/brightspace-auth-keys/package.json
@@ -9,6 +9,9 @@
     "LICENSE"
   ],
   "main": "src/index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "scripts": {
     "test": "nyc --all mocha --node-option enable-source-maps --recursive ./test"
   }

--- a/packages/node_modules/brightspace-auth-provisioning/package.json
+++ b/packages/node_modules/brightspace-auth-provisioning/package.json
@@ -8,6 +8,9 @@
     "LICENSE",
     "README.md"
   ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "scripts": {
     "test": "true"
   },

--- a/packages/node_modules/brightspace-auth-token/package.json
+++ b/packages/node_modules/brightspace-auth-token/package.json
@@ -7,6 +7,9 @@
     "README.md",
     "LICENSE"
   ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "main": "src/index.js",
   "scripts": {
     "test": "nyc --all --exclude spec mocha --node-option enable-source-maps spec"

--- a/packages/node_modules/brightspace-auth-validation/package.json
+++ b/packages/node_modules/brightspace-auth-validation/package.json
@@ -8,6 +8,9 @@
     "LICENSE"
   ],
   "main": "src/index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "scripts": {
     "test": "nyc --all mocha --node-option enable-source-maps -R spec spec"
   }


### PR DESCRIPTION
The `registry-url` input will soon be managed by Brightspace/setup-node itself.
The registry to publish packages to is now defined in `publishConfig` in `package.json`.

[HOD-4561 - Proxy Registry > Update Brightspace/setup-node](https://desire2learn.atlassian.net/browse/HOD-4561)